### PR TITLE
Add functionality to define explicit build number

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,7 @@ const defaults = rnv.getDefaults();
 program
 .version(pkg.version)
 .description(pkg.description)
-.arguments('[projectPath]')
+.arguments('[projectPath] [buildNumber]')
 /* eslint-disable max-len */
 .option('-a, --amend', 'Amend the previous commit. Also updates the latest Git tag to point to the amended commit. This is done automatically when ' + pkg.name + ' is run from the "version" or "postversion" npm script. Use "--never-amend" if you never want to amend.')
 .option('--skip-tag', 'For use with "--amend", if you don\'t want to update Git tags.')

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
-    "p-settle": "^2.0.0"
+    "p-settle": "^2.0.0",
+    "semver": "^5.4.1"
   },
   "devDependencies": {
     "ava": "^0.17.0",


### PR DESCRIPTION
Can be used with `react-native-version [path] 123` to set an explicit build number. Useful in CI environments where the updates are not committed.