### PR TITLE
Do not rely on tail to find the latest tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -395,8 +395,11 @@ function version(program, projectPath) {
 
 						if (!programOpts.skipTag) {
 							log({ text: "Adjusting Git tag..." }, programOpts.quiet);
+							const tags = child.execSync('git tag --sort=v:refname').toString().split('\n');
+							const tag = tags[tags.length - 2];
+
 							child.execSync(
-								"git tag -f $(git tag --sort=v:refname | tail -1)",
+								"git tag -f " + tag,
 								gitCmdOpts
 							);
 						}


### PR DESCRIPTION
`tail` is not available on windows, and running sub-shells
may produce different results depending on the host environment.