### PR TITLE
handle undefined targets

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function getPlistFilenames(xcode) {
 	return unique(
 		flattenDeep(
 			xcode.document.projects.map(project => {
-				return project.targets.map(target => {
+				return project.targets.filter(Boolean).map(target => {
 					return target.buildConfigurationsList.buildConfigurations.map(
 						config => {
 							return config.ast.value.get("buildSettings").get("INFOPLIST_FILE")
@@ -268,7 +268,7 @@ function version(program, projectPath) {
 
 				xcode.document.projects.forEach(project => {
 					!programOpts.neverIncrementBuild &&
-						project.targets.forEach(target => {
+						project.targets.filter(Boolean).forEach(target => {
 							target.buildConfigurationsList.buildConfigurations.forEach(
 								config => {
 									if (target.name === appPkg.name) {


### PR DESCRIPTION
I'm getting an error `[RNV] TypeError: Cannot read property 'buildConfigurationsList' of undefined` which I'm sure relates to something borked in my project file. Regardless, `undefined` targets should be handled. Happy to write this in a better way if anyone has a better approach. 