### PR TITLE
Fix git tag annotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -533,7 +533,10 @@ function version(program, projectPath) {
 
 						if (!programOpts.skipTag && latestTag) {
 							log({ text: "Adjusting Git tag..." }, programOpts.quiet);
-							child.execSync(`git tag -f ${latestTag}`, gitCmdOpts);
+							child.execSync(
+								`git tag -af ${latestTag} -m ${latestTag}`,
+								gitCmdOpts
+							);
 						}
 				}
 			}


### PR DESCRIPTION
This addresses an issue when re-creating the version tags.

npm and yarn will create an [annotated tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_annotated_tags) which may be pushed using `git push --follow-tags`.

`react-native-version` was replacing the annotated-tag with a [lightweight-tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_lightweight_tags). This break in convention meant that the typical workflow of `npm version patch && git push --follow-tags` would not push the version tag along with the commit.

This small tweak ensures the tags continue to be annotated after `react-native-version` runs.