### PR TITLE
fix: support custom version commit comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,8 +193,8 @@ function version(program, projectPath) {
 								versionCode: programOpts.setBuild
 									? programOpts.setBuild
 									: versionCode
-										? versionCode + 1
-										: 1
+									? versionCode + 1
+									: 1
 							})
 						})
 					});
@@ -237,8 +237,8 @@ function version(program, projectPath) {
 								buildNumber: programOpts.setBuild
 									? programOpts.setBuild.toString()
 									: buildNumber && !programOpts.resetBuild
-										? `${parseInt(buildNumber, 10) + 1}`
-										: "1"
+									? `${parseInt(buildNumber, 10) + 1}`
+									: "1"
 							})
 						})
 					});
@@ -503,10 +503,12 @@ function version(program, projectPath) {
 						process.env.npm_config_git_tag_version ||
 						process.env.npm_config_version_git_tag) &&
 					semver.valid(
-						child
-							.execSync("git log -1 --pretty=%s", gitCmdOpts)
-							.toString()
-							.trim()
+						semver.coerce(
+							child
+								.execSync("git log -1 --pretty=%s", gitCmdOpts)
+								.toString()
+								.trim()
+						)
 					) &&
 					child
 						.execSync("git describe --exact-match HEAD", gitCmdOpts)

--- a/test/helpers/tempInitAndVersion.js
+++ b/test/helpers/tempInitAndVersion.js
@@ -12,6 +12,6 @@ export default () => {
 		&& npm version major --ignore-scripts
 		&& npm version major --ignore-scripts
 		&& git checkout -q v2.0.0
-		&& npm version patch
+		&& npm version patch -m "chore(release): bump to version %s"
 		`);
 };


### PR DESCRIPTION
Solves #87

It makes the check a lot more permissive, since `semver.coerce` will try to get the version in a very loose way from the commit comment. But since this is an additional check on top of having a tag on the exact commit, and with the likely use cases this library should have (most of the times, in a postversion hook) my understanding is this should be fine. Please let me know what you think or if you have another idea you find better that I could also implement.

I opted by semver.coerce instead of using a regexp (as I originally said in #87) because if using a regexp, it should be a very long one (allowing everything that semver allows) and I didn't like the idea of having a regexp for something `semver` library already does. Sadly, they don't expose the regexps in a publicly enough way, so I opted for using `semver.coerce` instead, even when it's more permissive.