### PR TITLE
Add option to generate build number from version name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ $ react-native-version
     -q, --quiet                  Be quiet, only report errors.
     -r, --reset-build            Reset build number back to "1" (iOS only). Unlike Android's "versionCode", iOS doesn't require you to bump the "CFBundleVersion", as long as "CFBundleShortVersionString" changes. To make it consistent across platforms, react-native-version bumps both by default. You can use this option if you prefer to keep the build number value at "1" after every version change. If you then need to push another build under the same version, you can use "-bt ios" to increment.
     -s, --set-build <number>     Set a build number. WARNING: Watch out when setting high values. This option follows Android's app versioning specifics - the value has to be an integer and cannot be greater than 2100000000. You cannot decrement this value after publishing to Google Play! More info at: https://developer.android.com/studio/publish/versioning.html#appversioning
+    --generate-build             Generate build number from the package version number. (e.g. build number for version 1.2.3 will be 1002003)
     -t, --target <platforms>     Only version specified platforms, eg. "--target android,ios".
 
 <!-- END cli -->
@@ -166,7 +167,7 @@ version({
 
 Versions your app
 
-**Kind**: global function  
+**Kind**: global function
 **Returns**: <code>Promise.&lt;(string\|Error)&gt;</code> - A promise which resolves with the last commit hash
 
 | Param       | Type                | Description                             |
@@ -180,7 +181,7 @@ Versions your app
 
 Custom type definition for Promises
 
-**Kind**: global typedef  
+**Kind**: global typedef
 **Properties**
 
 | Name   | Type               | Description                                                        |

--- a/README.md
+++ b/README.md
@@ -58,21 +58,21 @@ $ react-native-version
 
 <!-- START cli -->
 
-    -h, --help                   output usage information
     -V, --version                output the version number
     -a, --amend                  Amend the previous commit. This is done automatically when react-native-version is run from the "version" or "postversion" npm script. Use "--never-amend" if you never want to amend. Also, if the previous commit is a valid npm-version commit, react-native-version will update the Git tag pointing to this commit.
     --skip-tag                   For use with "--amend", if you don't want to update Git tags. Use this option if you have git-tag-version set to false in your npm config or you use "--no-git-tag-version" during npm-version.
     -A, --never-amend            Never amend the previous commit.
     -b, --increment-build        Only increment build number.
     -B, --never-increment-build  Never increment build number.
-    -d, --android [path]         Path to your "android/app/build.gradle" file.
-    -i, --ios [path]             Path to your "ios/" folder.
+    -d, --android [path]         Path to your "android/app/build.gradle" file. (default: "android/app/build.gradle")
+    -i, --ios [path]             Path to your "ios/" folder. (default: "ios")
     -L, --legacy                 Version iOS using agvtool (macOS only). Requires Xcode Command Line Tools.
     -q, --quiet                  Be quiet, only report errors.
     -r, --reset-build            Reset build number back to "1" (iOS only). Unlike Android's "versionCode", iOS doesn't require you to bump the "CFBundleVersion", as long as "CFBundleShortVersionString" changes. To make it consistent across platforms, react-native-version bumps both by default. You can use this option if you prefer to keep the build number value at "1" after every version change. If you then need to push another build under the same version, you can use "-bt ios" to increment.
     -s, --set-build <number>     Set a build number. WARNING: Watch out when setting high values. This option follows Android's app versioning specifics - the value has to be an integer and cannot be greater than 2100000000. You cannot decrement this value after publishing to Google Play! More info at: https://developer.android.com/studio/publish/versioning.html#appversioning
-    --generate-build             Generate build number from the package version number. (e.g. build number for version 1.2.3 will be 1002003)
-    -t, --target <platforms>     Only version specified platforms, eg. "--target android,ios".
+    --generate-build             Generate build number from the package version number. (e.g. build number for version 1.22.3 will be 1022003)
+    -t, --target <platforms>     Only version specified platforms, e.g. "--target android,ios".
+    -h, --help                   output usage information
 
 <!-- END cli -->
 
@@ -167,7 +167,7 @@ version({
 
 Versions your app
 
-**Kind**: global function
+**Kind**: global function  
 **Returns**: <code>Promise.&lt;(string\|Error)&gt;</code> - A promise which resolves with the last commit hash
 
 | Param       | Type                | Description                             |
@@ -181,7 +181,7 @@ Versions your app
 
 Custom type definition for Promises
 
-**Kind**: global typedef
+**Kind**: global typedef  
 **Properties**
 
 | Name   | Type               | Description                                                        |

--- a/cli.js
+++ b/cli.js
@@ -46,11 +46,11 @@ program
 	)
 	.option(
 		"--generate-build",
-		"Generate build number from the package version number. (e.g. build number for version 1.2.3 will be 1002003)"
+		"Generate build number from the package version number. (e.g. build number for version 1.22.3 will be 1022003)"
 	)
 	.option(
 		"-t, --target <platforms>",
-		'Only version specified platforms, eg. "--target android,ios".',
+		'Only version specified platforms, e.g. "--target android,ios".',
 		list
 	)
 	.parse(process.argv);

--- a/cli.js
+++ b/cli.js
@@ -13,11 +13,7 @@ program
 	.arguments("[projectPath]")
 	.option(
 		"-a, --amend",
-		`Amend the previous commit. This is done automatically when ${
-			pkg.name
-		} is run from the "version" or "postversion" npm script. Use "--never-amend" if you never want to amend. Also, if the previous commit is a valid npm-version commit, ${
-			pkg.name
-		} will update the Git tag pointing to this commit.`
+		`Amend the previous commit. This is done automatically when ${pkg.name} is run from the "version" or "postversion" npm script. Use "--never-amend" if you never want to amend. Also, if the previous commit is a valid npm-version commit, ${pkg.name} will update the Git tag pointing to this commit.`
 	)
 	.option(
 		"--skip-tag",
@@ -47,6 +43,10 @@ program
 		"-s, --set-build <number>",
 		"Set a build number. WARNING: Watch out when setting high values. This option follows Android's app versioning specifics - the value has to be an integer and cannot be greater than 2100000000. You cannot decrement this value after publishing to Google Play! More info at: https://developer.android.com/studio/publish/versioning.html#appversioning",
 		parseInt
+	)
+	.option(
+		"--generate-build",
+		"Generate build number from the package version number. (e.g. build number for version 1.2.3 will be 1002003)"
 	)
 	.option(
 		"-t, --target <platforms>",

--- a/test/fixtures/version.json
+++ b/test/fixtures/version.json
@@ -25,6 +25,32 @@
       "versionCode": 2
     }
   },
+  "generateBuild": {
+    "AwesomeProject": {
+      "CFBundleShortVersionString": {
+        "AwesomeProject": "2.0.1",
+        "AwesomeProject-tvOS": "2.0.1",
+        "AwesomeProject-tvOSTests": "2.0.1",
+        "AwesomeProjectTests": "2.0.1"
+      },
+      "CFBundleVersion": {
+        "AwesomeProject": "2000001",
+        "AwesomeProject-tvOS": "2000001",
+        "AwesomeProject-tvOSTests": "2000001",
+        "AwesomeProjectTests": "2000001"
+      },
+      "CURRENT_PROJECT_VERSION": "2000001",
+      "version": "2.0.1",
+      "versionCode": "2000001",
+      "versionName": "2.0.1"
+    },
+    "my-new-project": {
+      "appVersion": "2.0.1",
+      "buildNumber": "2000001",
+      "version": "2.0.1",
+      "versionCode": 2000001
+    }
+  },
   "incrementBuild": {
     "AwesomeProject": {
       "CFBundleShortVersionString": {

--- a/test/generateBuild.js
+++ b/test/generateBuild.js
@@ -1,0 +1,113 @@
+import apiMacro from "./helpers/apiMacro";
+import cliMacro from "./helpers/cliMacro";
+import expected from "./fixtures";
+import npmScriptsMacro from "./helpers/npmScriptsMacro";
+import test from "ava";
+
+test(
+	"postversion (legacy)",
+	npmScriptsMacro,
+	{ postversion: "--generate-build -L" },
+	"AwesomeProject",
+	expected.version.generateBuild,
+	expected.tree.amended
+);
+
+test(
+	"postversion",
+	npmScriptsMacro,
+	{ postversion: "--generate-build" },
+	"AwesomeProject",
+	expected.version.generateBuild,
+	expected.tree.amended
+);
+
+test(
+	"postversion (Expo)",
+	npmScriptsMacro,
+	{ postversion: "--generate-build" },
+	"my-new-project",
+	expected.version.generateBuild,
+	expected.tree.amended
+);
+
+test(
+	"version (legacy)",
+	npmScriptsMacro,
+	{ version: "--generate-build -L" },
+	"AwesomeProject",
+	expected.version.generateBuild,
+	expected.tree.amended
+);
+
+test(
+	"version",
+	npmScriptsMacro,
+	{ version: "--generate-build" },
+	"AwesomeProject",
+	expected.version.generateBuild,
+	expected.tree.amended
+);
+
+test(
+	"version (Expo)",
+	npmScriptsMacro,
+	{ version: "--generate-build" },
+	"my-new-project",
+	expected.version.generateBuild,
+	expected.tree.amended
+);
+
+test(
+	"CLI (legacy)",
+	cliMacro,
+	["--generate-build", "-L"],
+	"AwesomeProject",
+	expected.version.generateBuild,
+	expected.tree.notAmended
+);
+
+test(
+	"CLI",
+	cliMacro,
+	["--generate-build"],
+	"AwesomeProject",
+	expected.version.generateBuild,
+	expected.tree.notAmended
+);
+
+test(
+	"CLI (Expo)",
+	cliMacro,
+	["--generate-build"],
+	"my-new-project",
+	expected.version.generateBuild,
+	expected.tree.notAmended
+);
+
+test(
+	"API (legacy)",
+	apiMacro,
+	{ generateBuild: true, legacy: true },
+	"AwesomeProject",
+	expected.version.generateBuild,
+	expected.tree.notAmended
+);
+
+test(
+	"API",
+	apiMacro,
+	{ generateBuild: true },
+	"AwesomeProject",
+	expected.version.generateBuild,
+	expected.tree.notAmended
+);
+
+test(
+	"API (Expo)",
+	apiMacro,
+	{ generateBuild: true },
+	"my-new-project",
+	expected.version.generateBuild,
+	expected.tree.notAmended
+);


### PR DESCRIPTION
This PR adds an option to generate a unique build number for each version (e.g. `1.2.3` becomes `1002003`).

This solves an issue with conflicting build numbers when releasing backported versions.

E.g.

```
Without --generate-build:

Release v1.2.0 from master branch with build number 24
Create v1.2.x support branch

Release v1.3.0 from master branch with build number 25
Create v1.3.x support branch

Backport fix to v1.2.x
Release v1.2.1 from v1.2.x with build number 25


With --generate-build:

Release v1.2.0 from master branch with build number 1002000
Create v1.2.x support branch

Release v1.3.0 from master branch with build number 1003000
Create v1.3.x support branch

Backport fix to v1.2.x
Release v1.2.1 from v1.2.x with build number 1002001
```