### PR TITLE
Added detection for properties managed by enviromental variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,15 @@ function isExpoProject(projPath) {
 }
 
 /**
+ * Determine if the given property is managed by an enviromental variable
+ * @param {String} text
+ * @return {Boolean} true if the given property is managed by an enviromental variable
+ */
+function isManagedByEnvVariable(propertyText) {
+	return propertyText ? !!/\$\(\S+\)/g.exec(propertyText) : false;
+}
+
+/**
  * Versions your app
  * @param {Object} program commander/CLI-style options, camelCased
  * @param {string} projectPath Path to your React Native project
@@ -431,7 +440,8 @@ function version(program, projectPath) {
 												CFBundleShortVersionString: appPkg.version
 										  }
 										: {},
-									!programOpts.neverIncrementBuild
+									!programOpts.neverIncrementBuild &&
+										!isManagedByEnvVariable(json.CFBundleVersion)
 										? {
 												CFBundleVersion: getNewVersionCode(
 													programOpts,


### PR DESCRIPTION
fixed issue #161 

added a function that detects if a given property is managed by an enviromental variable like
```
$(CURRENT_PROJECT_VERSION)
```
in case CFBundleVersion property in Info.plist is managed that way, the value will not be replaced.