### PR TITLE
Adds two CLI options: --is-bare-expo-workflow and --is-self-hosting-bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,20 +59,58 @@ $ react-native-version
 <!-- START cli -->
 
     -V, --version                output the version number
-    -a, --amend                  Amend the previous commit. This is done automatically when react-native-version is run from the "version" or "postversion" npm script. Use "--never-amend" if you never want to amend. Also, if the previous commit is a valid npm-version commit, react-native-version will update the Git tag pointing to this commit.
-    --skip-tag                   For use with "--amend", if you don't want to update Git tags. Use this option if you have git-tag-version set to false in your npm config or you use "--no-git-tag-version" during npm-version.
+    -a, --amend                  Amend the previous commit. This is done
+    automatically when react-native-version is run
+    from the "version" or "postversion" npm script.
+    Use "--never-amend" if you never want to amend.
+    Also, if the previous commit is a valid
+    npm-version commit, react-native-version will
+    update the Git tag pointing to this commit.
+    --skip-tag                   For use with "--amend", if you don't want to
+    update Git tags. Use this option if you have
+    git-tag-version set to false in your npm config
+    or you use "--no-git-tag-version" during
+    npm-version.
     -A, --never-amend            Never amend the previous commit.
     -b, --increment-build        Only increment build number.
     -B, --never-increment-build  Never increment build number.
-    -d, --android [path]         Path to your "android/app/build.gradle" file. (default: "android/app/build.gradle")
+    -d, --android [path]         Path to your "android/app/build.gradle" file.
+    (default: "android/app/build.gradle")
     -i, --ios [path]             Path to your "ios/" folder. (default: "ios")
-    -L, --legacy                 Version iOS using agvtool (macOS only). Requires Xcode Command Line Tools.
+    -L, --legacy                 Version iOS using agvtool (macOS only). Requires
+    Xcode Command Line Tools.
+    --is-bare-expo-workflow      Bare workflow expo apps want to update
+    *everything*. This will update the app.json
+    values and the /android and the /ios values.
+    --is-self-hosting-bundles    This will increment the values in the postExport
+    hook inside the app.json to what Sentry expects
+    when uploading sourcemaps. This value
+    auto-tracks your build version/build number.
     -q, --quiet                  Be quiet, only report errors.
-    -r, --reset-build            Reset build number back to "1" (iOS only). Unlike Android's "versionCode", iOS doesn't require you to bump the "CFBundleVersion", as long as "CFBundleShortVersionString" changes. To make it consistent across platforms, react-native-version bumps both by default. You can use this option if you prefer to keep the build number value at "1" after every version change. If you then need to push another build under the same version, you can use "-bt ios" to increment.
-    -s, --set-build <number>     Set a build number. WARNING: Watch out when setting high values. This option follows Android's app versioning specifics - the value has to be an integer and cannot be greater than 2100000000. You cannot decrement this value after publishing to Google Play! More info at: https://developer.android.com/studio/publish/versioning.html#appversioning
-    --generate-build             Generate build number from the package version number. (e.g. build number for version 1.22.3 will be 1022003)
-    -t, --target <platforms>     Only version specified platforms, e.g. "--target android,ios".
-    -h, --help                   output usage information
+    -r, --reset-build            Reset build number back to "1" (iOS only).
+    Unlike Android's "versionCode", iOS doesn't
+    require you to bump the "CFBundleVersion", as
+    long as "CFBundleShortVersionString" changes. To
+    make it consistent across platforms,
+    react-native-version bumps both by default. You
+    can use this option if you prefer to keep the
+    build number value at "1" after every version
+    change. If you then need to push another build
+    under the same version, you can use "-bt ios" to
+    increment.
+    -s, --set-build <number>     Set a build number. WARNING: Watch out when
+    setting high values. This option follows
+    Android's app versioning specifics - the value
+    has to be an integer and cannot be greater than
+    2100000000. You cannot decrement this value
+    after publishing to Google Play! More info at:
+    https://developer.android.com/studio/publish/versioning.html#appversioning
+    --generate-build             Generate build number from the package version
+    number. (e.g. build number for version 1.22.3
+    will be 1022003)
+    -t, --target <platforms>     Only version specified platforms, e.g. "--target
+    android,ios".
+    -h, --help                   display help for command
 
 <!-- END cli -->
 

--- a/cli.js
+++ b/cli.js
@@ -32,6 +32,8 @@ program
 		"-L, --legacy",
 		"Version iOS using agvtool (macOS only). Requires Xcode Command Line Tools."
 	)
+	.option("--is-bare-expo-workflow", "todo")
+	.option("--is-self-hosting-bundles", "todo")
 	.option("-q, --quiet", "Be quiet, only report errors.")
 	.option(
 		"-r, --reset-build",

--- a/cli.js
+++ b/cli.js
@@ -32,8 +32,8 @@ program
 		"-L, --legacy",
 		"Version iOS using agvtool (macOS only). Requires Xcode Command Line Tools."
 	)
-	.option("--is-bare-expo-workflow", "todo")
-	.option("--is-self-hosting-bundles", "todo")
+	.option("--is-bare-expo-workflow", "Bare workflow expo apps want to update *everything*. This will update the app.json values and the /android and the /ios values.")
+	.option("--is-self-hosting-bundles", "This will increment the values in the postExport hook inside the app.json to what Sentry expects when uploading sourcemaps. This value auto-tracks your build version/build number.")
 	.option("-q, --quiet", "Be quiet, only report errors.")
 	.option(
 		"-r, --reset-build",

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const Xcode = require("pbxproj-dom/xcode").Xcode;
  */
 
 const env = {
-	target: process.env.RNV && list(process.env.RNV),
+	target: process.env.RNV && list(process.env.RNV)
 };
 
 /**
@@ -34,7 +34,7 @@ const env = {
 function getDefaults() {
 	return {
 		android: "android/app/build.gradle",
-		ios: "ios",
+		ios: "ios"
 	};
 }
 
@@ -141,7 +141,7 @@ function version(program, projectPath) {
 
 	const programOpts = Object.assign({}, prog, {
 		android: path.join(projPath, prog.android),
-		ios: path.join(projPath, prog.ios),
+		ios: path.join(projPath, prog.ios)
 	});
 
 	const targets = [].concat(programOpts.target, env.target).filter(Boolean);
@@ -154,24 +154,24 @@ function version(program, projectPath) {
 		if (err.message === "Cannot find module 'react-native'") {
 			log({
 				style: "red",
-				text: `Is this the right folder? ${err.message} in ${projPath}`,
+				text: `Is this the right folder? ${err.message} in ${projPath}`
 			});
 		} else {
 			log({
 				style: "red",
-				text: err.message,
+				text: err.message
 			});
 
 			log({
 				style: "red",
 				text:
-					"Is this the right folder? Looks like there isn't a package.json here",
+					"Is this the right folder? Looks like there isn't a package.json here"
 			});
 		}
 
 		log({
 			style: "yellow",
-			text: "Pass the project path as an argument, see --help for usage",
+			text: "Pass the project path as an argument, see --help for usage"
 		});
 
 		if (program.outputHelp) {
@@ -194,8 +194,8 @@ function version(program, projectPath) {
 		if (isExpoApp && !programOpts.incrementBuild) {
 			appJSON = Object.assign({}, appJSON, {
 				expo: Object.assign({}, appJSON.expo, {
-					version: appPkg.version,
-				}),
+					version: appPkg.version
+				})
 			});
 		}
 	} catch (err) {}
@@ -215,12 +215,12 @@ function version(program, projectPath) {
 					reject([
 						{
 							style: "red",
-							text: "No gradle file found at " + programOpts.android,
+							text: "No gradle file found at " + programOpts.android
 						},
 						{
 							style: "yellow",
-							text: 'Use the "--android" option to specify the path manually',
-						},
+							text: 'Use the "--android" option to specify the path manually'
+						}
 					]);
 			}
 
@@ -242,9 +242,9 @@ function version(program, projectPath) {
 									programOpts,
 									versionCode,
 									appPkg.version
-								),
-							}),
-						}),
+								)
+							})
+						})
 					});
 				} else {
 					gradleFile = gradleFile.replace(/versionCode (\d+)/, function (
@@ -275,9 +275,9 @@ function version(program, projectPath) {
 				appJSON = Object.assign({}, appJSON, {
 					expo: Object.assign({}, appJSON.expo, {
 						android: Object.assign({}, appJSON.expo.android, {
-							versionCode: newVersionCode,
-						}),
-					}),
+							versionCode: newVersionCode
+						})
+					})
 				});
 
 				gradleFile = gradleFile.replace(/versionCode (\d+)/, function (
@@ -318,9 +318,9 @@ function version(program, projectPath) {
 					appJSON = Object.assign({}, appJSON, {
 						expo: Object.assign({}, appJSON.expo, {
 							ios: Object.assign({}, appJSON.expo.ios, {
-								buildNumber: newBuildVersion,
-							}),
-						}),
+								buildNumber: newBuildVersion
+							})
+						})
 					});
 
 					if (appJSON.expo.hooks) {
@@ -340,15 +340,15 @@ function version(program, projectPath) {
 														appPkg.version +
 														"+" +
 														newBuildVersion,
-													distribution: newBuildVersion,
-												}),
+													distribution: newBuildVersion
+												})
 											};
 										} else {
 											return hook;
 										}
-									}),
-								}),
-							}),
+									})
+								})
+							})
 						});
 					}
 				}
@@ -367,37 +367,37 @@ function version(program, projectPath) {
 					appJSON = Object.assign({}, appJSON, {
 						expo: Object.assign({}, appJSON.expo, {
 							ios: Object.assign({}, appJSON.expo.ios, {
-								buildNumber: newBuildVersion,
-							}),
-						}),
+								buildNumber: newBuildVersion
+							})
+						})
 					});
 					fs.writeFileSync(appJSONPath, JSON.stringify(appJSON, null, 2));
 				}
 			} else if (program.legacy) {
 				try {
 					child.execSync("xcode-select --print-path", {
-						stdio: ["ignore", "ignore", "pipe"],
+						stdio: ["ignore", "ignore", "pipe"]
 					});
 				} catch (err) {
 					reject([
 						{
 							style: "red",
-							text: err,
+							text: err
 						},
 						{
 							style: "yellow",
-							text: "Looks like Xcode Command Line Tools aren't installed",
+							text: "Looks like Xcode Command Line Tools aren't installed"
 						},
 						{
-							text: "\n  Install:\n\n    $ xcode-select --install\n",
-						},
+							text: "\n  Install:\n\n    $ xcode-select --install\n"
+						}
 					]);
 
 					return;
 				}
 
 				const agvtoolOpts = {
-					cwd: programOpts.ios,
+					cwd: programOpts.ios
 				};
 
 				try {
@@ -410,18 +410,18 @@ function version(program, projectPath) {
 							? [
 									{
 										style: "red",
-										text: "No project folder found at " + programOpts.ios,
+										text: "No project folder found at " + programOpts.ios
 									},
 									{
 										style: "yellow",
-										text: 'Use the "--ios" option to specify the path manually',
-									},
+										text: 'Use the "--ios" option to specify the path manually'
+									}
 							  ]
 							: [
 									{
 										style: "red",
-										text: stdout,
-									},
+										text: stdout
+									}
 							  ]
 					);
 
@@ -491,8 +491,8 @@ function version(program, projectPath) {
 
 										config.patch({
 											buildSettings: {
-												CURRENT_PROJECT_VERSION,
-											},
+												CURRENT_PROJECT_VERSION
+											}
 										});
 									}
 								}
@@ -521,7 +521,7 @@ function version(program, projectPath) {
 										? {
 												CFBundleShortVersionString: getCFBundleShortVersionString(
 													appPkg.version
-												),
+												)
 										  }
 										: {},
 									!programOpts.neverIncrementBuild
@@ -531,7 +531,7 @@ function version(program, projectPath) {
 													parseInt(json.CFBundleVersion, 10),
 													appPkg.version,
 													programOpts.resetBuild
-												).toString(),
+												).toString()
 										  }
 										: {}
 								)
@@ -615,7 +615,7 @@ function version(program, projectPath) {
 			}
 
 			const gitCmdOpts = {
-				cwd: projPath,
+				cwd: projPath
 			};
 
 			if (
@@ -674,7 +674,7 @@ function version(program, projectPath) {
 			log(
 				{
 					style: "green",
-					text: "Done",
+					text: "Done"
 				},
 				programOpts.quiet
 			);
@@ -692,7 +692,7 @@ function version(program, projectPath) {
 
 			log({
 				style: "red",
-				text: "Done, with errors.",
+				text: "Done, with errors."
 			});
 
 			process.exit(1);
@@ -704,5 +704,5 @@ module.exports = {
 	getDefaults: getDefaults,
 	getPlistFilenames: getPlistFilenames,
 	isExpoProject: isExpoProject,
-	version: version,
+	version: version
 };

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const Xcode = require("pbxproj-dom/xcode").Xcode;
  */
 
 const env = {
-	target: process.env.RNV && list(process.env.RNV)
+	target: process.env.RNV && list(process.env.RNV),
 };
 
 /**
@@ -34,7 +34,7 @@ const env = {
 function getDefaults() {
 	return {
 		android: "android/app/build.gradle",
-		ios: "ios"
+		ios: "ios",
 	};
 }
 
@@ -47,10 +47,10 @@ function getDefaults() {
 function getPlistFilenames(xcode) {
 	return unique(
 		flattenDeep(
-			xcode.document.projects.map(project => {
-				return project.targets.filter(Boolean).map(target => {
+			xcode.document.projects.map((project) => {
+				return project.targets.filter(Boolean).map((target) => {
 					return target.buildConfigurationsList.buildConfigurations.map(
-						config => {
+						(config) => {
 							return config.ast.value.get("buildSettings").get("INFOPLIST_FILE")
 								.text;
 						}
@@ -141,7 +141,7 @@ function version(program, projectPath) {
 
 	const programOpts = Object.assign({}, prog, {
 		android: path.join(projPath, prog.android),
-		ios: path.join(projPath, prog.ios)
+		ios: path.join(projPath, prog.ios),
 	});
 
 	const targets = [].concat(programOpts.target, env.target).filter(Boolean);
@@ -154,24 +154,24 @@ function version(program, projectPath) {
 		if (err.message === "Cannot find module 'react-native'") {
 			log({
 				style: "red",
-				text: `Is this the right folder? ${err.message} in ${projPath}`
+				text: `Is this the right folder? ${err.message} in ${projPath}`,
 			});
 		} else {
 			log({
 				style: "red",
-				text: err.message
+				text: err.message,
 			});
 
 			log({
 				style: "red",
 				text:
-					"Is this the right folder? Looks like there isn't a package.json here"
+					"Is this the right folder? Looks like there isn't a package.json here",
 			});
 		}
 
 		log({
 			style: "yellow",
-			text: "Pass the project path as an argument, see --help for usage"
+			text: "Pass the project path as an argument, see --help for usage",
 		});
 
 		if (program.outputHelp) {
@@ -194,8 +194,8 @@ function version(program, projectPath) {
 		if (isExpoApp && !programOpts.incrementBuild) {
 			appJSON = Object.assign({}, appJSON, {
 				expo: Object.assign({}, appJSON.expo, {
-					version: appPkg.version
-				})
+					version: appPkg.version,
+				}),
 			});
 		}
 	} catch (err) {}
@@ -204,11 +204,10 @@ function version(program, projectPath) {
 	var ios;
 
 	if (!targets.length || targets.indexOf("android") > -1) {
-		android = new Promise(function(resolve, reject) {
+		android = new Promise(function (resolve, reject) {
 			log({ text: "Versioning Android..." }, programOpts.quiet);
 
 			var gradleFile;
-
 			try {
 				gradleFile = fs.readFileSync(programOpts.android, "utf8");
 			} catch (err) {
@@ -216,12 +215,12 @@ function version(program, projectPath) {
 					reject([
 						{
 							style: "red",
-							text: "No gradle file found at " + programOpts.android
+							text: "No gradle file found at " + programOpts.android,
 						},
 						{
 							style: "yellow",
-							text: 'Use the "--android" option to specify the path manually'
-						}
+							text: 'Use the "--android" option to specify the path manually',
+						},
 					]);
 			}
 
@@ -243,12 +242,12 @@ function version(program, projectPath) {
 									programOpts,
 									versionCode,
 									appPkg.version
-								)
-							})
-						})
+								),
+							}),
+						}),
 					});
 				} else {
-					gradleFile = gradleFile.replace(/versionCode (\d+)/, function(
+					gradleFile = gradleFile.replace(/versionCode (\d+)/, function (
 						match,
 						cg1
 					) {
@@ -264,7 +263,7 @@ function version(program, projectPath) {
 			}
 
 			if (isBareExpoWorkflow) {
-			// if bare expo workflow, combine the two exclusive blocks above
+				// if bare expo workflow, combine the two exclusive blocks above
 				const versionCode = parseInt(
 					dottie.get(appJSON, "expo.android.versionCode")
 				);
@@ -276,12 +275,12 @@ function version(program, projectPath) {
 				appJSON = Object.assign({}, appJSON, {
 					expo: Object.assign({}, appJSON.expo, {
 						android: Object.assign({}, appJSON.expo.android, {
-							versionCode: newVersionCode
-						})
-					})
+							versionCode: newVersionCode,
+						}),
+					}),
 				});
 
-				gradleFile = gradleFile.replace(/versionCode (\d+)/, function(
+				gradleFile = gradleFile.replace(/versionCode (\d+)/, function (
 					match,
 					cg1
 				) {
@@ -303,7 +302,7 @@ function version(program, projectPath) {
 	}
 
 	if (!targets.length || targets.indexOf("ios") > -1) {
-		ios = new Promise(function(resolve, reject) {
+		ios = new Promise(function (resolve, reject) {
 			log({ text: "Versioning iOS..." }, programOpts.quiet);
 
 			if (isExpoApp || isBareExpoWorkflow) {
@@ -316,13 +315,12 @@ function version(program, projectPath) {
 						programOpts.resetBuild
 					).toString();
 
-
 					appJSON = Object.assign({}, appJSON, {
 						expo: Object.assign({}, appJSON.expo, {
 							ios: Object.assign({}, appJSON.expo.ios, {
-								buildNumber: newBuildVersion
-							})
-						})
+								buildNumber: newBuildVersion,
+							}),
+						}),
 					});
 
 					if (appJSON.expo.hooks) {
@@ -330,7 +328,9 @@ function version(program, projectPath) {
 							expo: Object.assign({}, appJSON.expo, {
 								hooks: Object.assign({}, appJSON.expo.hooks, {
 									// someone can add their own postPub
-									postExport: appJSON.expo.hooks.postExport.map(function(hook) {
+									postExport: appJSON.expo.hooks.postExport.map(function (
+										hook
+									) {
 										if (hook.file === "sentry-expo/upload-sourcemaps") {
 											return {
 												file: "sentry-expo/upload-sourcemaps",
@@ -340,45 +340,45 @@ function version(program, projectPath) {
 														appPkg.version +
 														"+" +
 														newBuildVersion,
-													distribution: newBuildVersion
-												})
+													distribution: newBuildVersion,
+												}),
 											};
 										} else {
 											return hook;
 										}
-									})
-								})
-							})
+									}),
+								}),
+							}),
 						});
 					}
 				}
 				fs.writeFileSync(appJSONPath, JSON.stringify(appJSON, null, 2));
-			}  
+			}
 			if (program.legacy) {
 				try {
 					child.execSync("xcode-select --print-path", {
-						stdio: ["ignore", "ignore", "pipe"]
+						stdio: ["ignore", "ignore", "pipe"],
 					});
 				} catch (err) {
 					reject([
 						{
 							style: "red",
-							text: err
+							text: err,
 						},
 						{
 							style: "yellow",
-							text: "Looks like Xcode Command Line Tools aren't installed"
+							text: "Looks like Xcode Command Line Tools aren't installed",
 						},
 						{
-							text: "\n  Install:\n\n    $ xcode-select --install\n"
-						}
+							text: "\n  Install:\n\n    $ xcode-select --install\n",
+						},
 					]);
 
 					return;
 				}
 
 				const agvtoolOpts = {
-					cwd: programOpts.ios
+					cwd: programOpts.ios,
 				};
 
 				try {
@@ -391,18 +391,18 @@ function version(program, projectPath) {
 							? [
 									{
 										style: "red",
-										text: "No project folder found at " + programOpts.ios
+										text: "No project folder found at " + programOpts.ios,
 									},
 									{
 										style: "yellow",
-										text: 'Use the "--ios" option to specify the path manually'
-									}
+										text: 'Use the "--ios" option to specify the path manually',
+									},
 							  ]
 							: [
 									{
 										style: "red",
-										text: stdout
-									}
+										text: stdout,
+									},
 							  ]
 					);
 
@@ -442,7 +442,7 @@ function version(program, projectPath) {
 				// Find any folder ending in .xcodeproj
 				const xcodeProjects = fs
 					.readdirSync(programOpts.ios)
-					.filter(file => /\.xcodeproj$/i.test(file));
+					.filter((file) => /\.xcodeproj$/i.test(file));
 
 				if (xcodeProjects.length < 1) {
 					throw new Error(`Xcode project not found in "${programOpts.ios}"`);
@@ -452,11 +452,11 @@ function version(program, projectPath) {
 				const xcode = Xcode.open(path.join(projectFolder, "project.pbxproj"));
 				const plistFilenames = getPlistFilenames(xcode);
 
-				xcode.document.projects.forEach(project => {
+				xcode.document.projects.forEach((project) => {
 					!programOpts.neverIncrementBuild &&
-						project.targets.filter(Boolean).forEach(target => {
+						project.targets.filter(Boolean).forEach((target) => {
 							target.buildConfigurationsList.buildConfigurations.forEach(
-								config => {
+								(config) => {
 									if (target.name === appPkg.name) {
 										const CURRENT_PROJECT_VERSION = getNewVersionCode(
 											programOpts,
@@ -472,22 +472,22 @@ function version(program, projectPath) {
 
 										config.patch({
 											buildSettings: {
-												CURRENT_PROJECT_VERSION
-											}
+												CURRENT_PROJECT_VERSION,
+											},
 										});
 									}
 								}
 							);
 						});
 
-					const plistFiles = plistFilenames.map(filename => {
+					const plistFiles = plistFilenames.map((filename) => {
 						return fs.readFileSync(
 							path.join(programOpts.ios, filename),
 							"utf8"
 						);
 					});
 
-					const parsedPlistFiles = plistFiles.map(file => {
+					const parsedPlistFiles = plistFiles.map((file) => {
 						return plist.parse(file);
 					});
 
@@ -502,7 +502,7 @@ function version(program, projectPath) {
 										? {
 												CFBundleShortVersionString: getCFBundleShortVersionString(
 													appPkg.version
-												)
+												),
 										  }
 										: {},
 									!programOpts.neverIncrementBuild
@@ -512,7 +512,7 @@ function version(program, projectPath) {
 													parseInt(json.CFBundleVersion, 10),
 													appPkg.version,
 													programOpts.resetBuild
-												).toString()
+												).toString(),
 										  }
 										: {}
 								)
@@ -557,21 +557,21 @@ function version(program, projectPath) {
 	}
 
 	return pSettle([android, ios].filter(Boolean))
-		.then(function(result) {
+		.then(function (result) {
 			const errs = result
-				.filter(function(item) {
+				.filter(function (item) {
 					return item.isRejected;
 				})
-				.map(function(item) {
+				.map(function (item) {
 					return item.reason;
 				});
 
 			if (errs.length) {
 				errs
-					.reduce(function(a, b) {
+					.reduce(function (a, b) {
 						return a.concat(b);
 					}, [])
-					.forEach(function(err) {
+					.forEach(function (err) {
 						if (program.outputHelp) {
 							log(
 								Object.assign({ style: "red", text: err.toString() }, err),
@@ -585,9 +585,9 @@ function version(program, projectPath) {
 				}
 
 				throw errs
-					.map(function(errGrp, index) {
+					.map(function (errGrp, index) {
 						return errGrp
-							.map(function(err) {
+							.map(function (err) {
 								return err.text;
 							})
 							.join(", ");
@@ -596,7 +596,7 @@ function version(program, projectPath) {
 			}
 
 			const gitCmdOpts = {
-				cwd: projPath
+				cwd: projPath,
 			};
 
 			if (
@@ -655,7 +655,7 @@ function version(program, projectPath) {
 			log(
 				{
 					style: "green",
-					text: "Done"
+					text: "Done",
 				},
 				programOpts.quiet
 			);
@@ -666,14 +666,14 @@ function version(program, projectPath) {
 
 			return child.execSync("git log -1 --pretty=%H", gitCmdOpts).toString();
 		})
-		.catch(function(err) {
+		.catch(function (err) {
 			if (process.env.RNV_ENV === "ava") {
 				console.error(err);
 			}
 
 			log({
 				style: "red",
-				text: "Done, with errors."
+				text: "Done, with errors.",
 			});
 
 			process.exit(1);
@@ -685,5 +685,5 @@ module.exports = {
 	getDefaults: getDefaults,
 	getPlistFilenames: getPlistFilenames,
 	isExpoProject: isExpoProject,
-	version: version
+	version: version,
 };


### PR DESCRIPTION
I've got a semi-specific use case for a Bare Workflow Expo app, and thought I'd try to upstream these changes in to see if others may also find it useful.

This adds two new CLI options:

1. `--is-bare-expo-workflow`
Bare workflow expo apps potentially want to update *everything*. This includes the app.json, the ios stuff and the android stuff. Currently, this library only supports updating the app.json vs. native code depending on it's awkward definition of an "expo" app. Some of the pathways in the library don't allow both, where this argument will go out of it's way to update both.

2. `--is-self-hosting-bundles`
This one is a bit more esoteric, but it's meant for bare workflow apps using sentry-expo to upload their source-maps in a postExport hook, where it's essential to keep the release/dist versions aligned with the build/release versions. If it's passed in, it will look in the hooks inside the app.json file to update these values as needed to their newly bumped versions.

Combined, these two flags allow us to have a workflow where we can run `npm version patch`, which then updates the package.json, the app.json, the /android values, the /ios values, as well as updates our postExport hook in the app.json.

Thanks for the library! Hope you'll consider these changes. All tests still pass.