### PR TITLE
Feature/allow invalid short version string flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,21 +58,64 @@ $ react-native-version
 
 <!-- START cli -->
 
-    -V, --version                output the version number
-    -a, --amend                  Amend the previous commit. This is done automatically when react-native-version is run from the "version" or "postversion" npm script. Use "--never-amend" if you never want to amend. Also, if the previous commit is a valid npm-version commit, react-native-version will update the Git tag pointing to this commit.
-    --skip-tag                   For use with "--amend", if you don't want to update Git tags. Use this option if you have git-tag-version set to false in your npm config or you use "--no-git-tag-version" during npm-version.
-    -A, --never-amend            Never amend the previous commit.
-    -b, --increment-build        Only increment build number.
-    -B, --never-increment-build  Never increment build number.
-    -d, --android [path]         Path to your "android/app/build.gradle" file. (default: "android/app/build.gradle")
-    -i, --ios [path]             Path to your "ios/" folder. (default: "ios")
-    -L, --legacy                 Version iOS using agvtool (macOS only). Requires Xcode Command Line Tools.
-    -q, --quiet                  Be quiet, only report errors.
-    -r, --reset-build            Reset build number back to "1" (iOS only). Unlike Android's "versionCode", iOS doesn't require you to bump the "CFBundleVersion", as long as "CFBundleShortVersionString" changes. To make it consistent across platforms, react-native-version bumps both by default. You can use this option if you prefer to keep the build number value at "1" after every version change. If you then need to push another build under the same version, you can use "-bt ios" to increment.
-    -s, --set-build <number>     Set a build number. WARNING: Watch out when setting high values. This option follows Android's app versioning specifics - the value has to be an integer and cannot be greater than 2100000000. You cannot decrement this value after publishing to Google Play! More info at: https://developer.android.com/studio/publish/versioning.html#appversioning
-    --generate-build             Generate build number from the package version number. (e.g. build number for version 1.22.3 will be 1022003)
-    -t, --target <platforms>     Only version specified platforms, e.g. "--target android,ios".
-    -h, --help                   output usage information
+    -V, --version                         output the version number
+    -a, --amend                           Amend the previous commit. This is done
+    automatically when react-native-version
+    is run from the "version" or
+    "postversion" npm script. Use
+    "--never-amend" if you never want to
+    amend. Also, if the previous commit is
+    a valid npm-version commit,
+    react-native-version will update the
+    Git tag pointing to this commit.
+    --skip-tag                            For use with "--amend", if you don't
+    want to update Git tags. Use this
+    option if you have git-tag-version set
+    to false in your npm config or you use
+    "--no-git-tag-version" during
+    npm-version.
+    -A, --never-amend                     Never amend the previous commit.
+    -b, --increment-build                 Only increment build number.
+    -B, --never-increment-build           Never increment build number.
+    -d, --android [path]                  Path to your "android/app/build.gradle"
+    file. (default:
+    "android/app/build.gradle")
+    -i, --ios [path]                      Path to your "ios/" folder. (default:
+    "ios")
+    -L, --legacy                          Version iOS using agvtool (macOS only).
+    Requires Xcode Command Line Tools.
+    -q, --quiet                           Be quiet, only report errors.
+    -r, --reset-build                     Reset build number back to "1" (iOS
+    only). Unlike Android's "versionCode",
+    iOS doesn't require you to bump the
+    "CFBundleVersion", as long as
+    "CFBundleShortVersionString" changes.
+    To make it consistent across platforms,
+    react-native-version bumps both by
+    default. You can use this option if you
+    prefer to keep the build number value
+    at "1" after every version change. If
+    you then need to push another build
+    under the same version, you can use
+    "-bt ios" to increment.
+    -s, --set-build <number>              Set a build number. WARNING: Watch out
+    when setting high values. This option
+    follows Android's app versioning
+    specifics - the value has to be an
+    integer and cannot be greater than
+    2100000000. You cannot decrement this
+    value after publishing to Google Play!
+    More info at:
+    https://developer.android.com/studio/publish/versioning.html#appversioning
+    --generate-build                      Generate build number from the package
+    version number. (e.g. build number for
+    version 1.22.3 will be 1022003)
+    -t, --target <platforms>              Only version specified platforms, e.g.
+    "--target android,ios".
+    --allow-invalid-short-version-string  Allow invalid value for
+    CFBundleShortVersionString. (e.g.
+    1.5.0-staging.1.
+    -h, --help                            display help for command
 
 <!-- END cli -->
 

--- a/cli.js
+++ b/cli.js
@@ -53,6 +53,7 @@ program
 		'Only version specified platforms, e.g. "--target android,ios".',
 		list
 	)
+	.option("--allow-invalid-short-version-string", "Allow invalid value for CFBundleShortVersionString. (e.g. 1.5.0-staging.1.")
 	.parse(process.argv);
 
 rnv.version(program);

--- a/index.js
+++ b/index.js
@@ -99,9 +99,14 @@ function getNewVersionCode(programOpts, versionCode, versionName, resetBuild) {
  * CFBundleShortVersionString must be a string composed of three period-separated integers.
  * @private
  * @param {String} versionName The full version string
+ * @param {Boolean} allowInvalidShortVersionString Whether or not to allow short version strings like '1.2.3-beta.1'
  * @return {String} e.g. returns '1.2.3' for given '1.2.3-beta.1'. Returns `versionName` if no match is found.
  */
-function getCFBundleShortVersionString(versionName) {
+function getCFBundleShortVersionString(versionName, allowInvalidShortVersionString = false) {
+	if (allowInvalidShortVersionString) {
+		return versionName
+	}
+
 	const match =
 		versionName && typeof versionName === "string"
 			? versionName.match(/\d*\.\d*.\d*/g)
@@ -443,7 +448,8 @@ function version(program, projectPath) {
 									!programOpts.incrementBuild
 										? {
 												CFBundleShortVersionString: getCFBundleShortVersionString(
-													appPkg.version
+													appPkg.version,
+													programOpts.allowInvalidShortVersionString,
 												)
 										  }
 										: {},

--- a/test/shortBundleVerions.js
+++ b/test/shortBundleVerions.js
@@ -48,3 +48,19 @@ test(
 		t.is(v, 'garbage');
 	}
 );
+
+test(
+	"CFBundleShortVersionString allow invalid, with invalid",
+	t => {
+		const v = getCFBundleShortVersionString('1.2.3-staging.1', true);
+		t.is(v, '1.2.3-staging.1');
+	}
+);
+
+test(
+	"CFBundleShortVersionString allow invalid, with valid",
+	t => {
+		const v = getCFBundleShortVersionString('1.2.3', true);
+		t.is(v, '1.2.3');
+	}
+);


### PR DESCRIPTION
Adds a new flag `--allow-invalid-short-version-string`. If provided, it allows invalid versions as `CFBundleShortVersionString` such as `1.2.3-staging.1` on iOS.

Useful when deploying different environments to Firebase App Distribution.

Relates to #86 