### PR TITLE
Feat: Added support to select a single info plist file out of multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ $ react-native-version
     -s, --set-build <number>     Set a build number. WARNING: Watch out when setting high values. This option follows Android's app versioning specifics - the value has to be an integer and cannot be greater than 2100000000. You cannot decrement this value after publishing to Google Play! More info at: https://developer.android.com/studio/publish/versioning.html#appversioning
     --generate-build             Generate build number from the package version number. (e.g. build number for version 1.22.3 will be 1022003)
     -t, --target <platforms>     Only version specified platforms, e.g. "--target android,ios".
+    -p, --plist [name]           Name of the iOS Info Plist file that should reflect the new version (optional)
     -h, --help                   output usage information
 
 <!-- END cli -->

--- a/cli.js
+++ b/cli.js
@@ -53,6 +53,7 @@ program
 		'Only version specified platforms, e.g. "--target android,ios".',
 		list
 	)
+	.option("-p, --plist [name]", 'Name of the iOS Info Plist file" folder.')
 	.parse(process.argv);
 
 rnv.version(program);

--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ function version(program, projectPath) {
 
 				const projectFolder = path.join(programOpts.ios, xcodeProjects[0]);
 				const xcode = Xcode.open(path.join(projectFolder, "project.pbxproj"));
-				const plistFilenames = getPlistFilenames(xcode);
+				const plistFilenames = programOpts.plist? [programOpts.plist] : getPlistFilenames(xcode);
 
 				xcode.document.projects.forEach(project => {
 					!programOpts.neverIncrementBuild &&


### PR DESCRIPTION
### Summary

This MR introduces a new feature where a user can specify which info.plist file should be changes when multiple files presents. 

### Why this Matters

In some project scenarios, you may find multiple info.plist files have been created to manage different configurations across various environments. Previously, when you executed react-native-version, it would automatically update all info.plist files. However, this wasn't always necessary or desired.

### The Solution

To address this, this new feature can be used. Now, when running the execution command, you can specify the exact info.plist file you want to change. This means you have more control and flexibility, reducing unnecessary modifications across all your info.plist files.